### PR TITLE
Add unique alpha mobjs

### DIFF
--- a/Build/Configurations/Includes/ExPlus_things.cfg
+++ b/Build/Configurations/Includes/ExPlus_things.cfg
@@ -36,3 +36,76 @@ monsters
 		height = 90;
 	}
 }
+
+alpha
+{
+	color = 4;
+	arrow = 0;
+	title = "Decorations (Alpha)";
+	width = 20;
+	sort = 1;
+	height = 16;
+	hangs = 0;
+	blocking = 2;
+	
+	1021
+	{
+		title = "Chandelier";
+		sprite = "S021A0";
+		radius = 20;
+		height = 97;
+		hangs = 1;
+		blocking = 0;
+	}
+	1027
+	{
+		title = "Stone Pillar";
+		sprite = "S027A0";
+		width = 14;
+		height = 80;
+	}
+	45
+	{
+		title = "Stone Pillar (Large Hitbox)";
+		sprite = "S027A0";
+		width = 32;
+		height = 81;
+	}
+	1040
+	{
+		title = "Corpse Hanging by Wrists";
+		sprite = "S040A0";
+		width = 32;
+		height = 16;
+	}
+	1041
+	{
+		title = "Big Rock";
+		sprite = "S041A0";
+		width = 20;
+		height = 16;
+		blocking = 0;
+	}
+	1026
+	{
+		title = "Small Rock";
+		sprite = "S026A0";
+		width = 20;
+		height = 16;
+		blocking = 0;
+	}
+	70
+	{
+		title = "Burning Barrel";
+		sprite = "S002A0";
+		width = 16;
+		height = 16;
+	}
+	1030
+	{
+		title = "Torch Short Red";
+		sprite = "S030A0";
+		width = 8;
+		height = 62;
+	}
+}


### PR DESCRIPTION
These mobjs are also supported by explus, but only work if the alpha wad is loaded or the sprites are supplied in a pwad