### PR TITLE
Increasing ActionTypes to 1024 from 511

### DIFF
--- a/Source/Core/IO/Doom64MapSetIO.cs
+++ b/Source/Core/IO/Doom64MapSetIO.cs
@@ -78,7 +78,7 @@ namespace CodeImp.DoomBuilder.IO
         public override bool HasNumericLinedefActivations { get { return true; } }
         public override int MaxTag { get { return ushort.MaxValue; } }
         public override int MinTag { get { return ushort.MinValue; } }
-        public override int MaxAction { get { return 511; } }
+        public override int MaxAction { get { return 1024; } }
         public override int MinAction { get { return ushort.MinValue; } }
         public override int MaxArgument { get { return 0; } }
         public override int MinArgument { get { return 0; } }


### PR DESCRIPTION
This allows more ActionTypes, up to 1024 for EX+ without compromising mapping ability for the Remaster.