### PR TITLE
Artifact Switch Macro Commands

### DIFF
--- a/Build/Compilers/Doom64/common.txt
+++ b/Build/Compilers/Doom64/common.txt
@@ -213,3 +213,6 @@
 #define UnlockCheatMenu                                 253:0
 #define DisplaySkyLogo                                  254:0
 #define No_Op                                           0:0
+#define Orange_Artifact_Switch(tag)						90:tag
+#define Blue_Artifact_Switch(tag)						91:tag
+#define Purple_Artifact_Switch(tag)						92:tag


### PR DESCRIPTION
The actions which require artifacts can be used in macros as well. Note that these commands will activate a linedef at one tag higher than the specified tag if the player has the corresponding artifact.